### PR TITLE
Fixed isSupported not returning true for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $(selector).playKeyframe({
     delay: 0, //[optional, default: 0, in ms]  how long you want to wait before the animation starts in milliseconds, default value is 0
     repeat: 'infinite', //[optional, default:1]  how many times you want the animation to repeat, default value is 1
     direction: 'normal', //[optional, default: 'normal']  which direction you want the frames to flow, default value is normal
-    fillMode: 'forwards' //[optional, default: 'forward']  how to apply the styles outside the animation time, default value is forwards
+    fillMode: 'forwards', //[optional, default: 'forward']  how to apply the styles outside the animation time, default value is forwards
     complete: function(){} //[optional]  Function fired after the animation is complete. If repeat is infinite, the function will be fired every time the animation is restarted.
 });
 ```

--- a/jquery.keyframes.js
+++ b/jquery.keyframes.js
@@ -31,10 +31,13 @@
 		animationSupport = true;
 	    } else {
 		pfx = this.vendorPrefix().slice(1, -1);
-		if (element.style[pfx + "AnimationName"]) {
+		var property = pfx + "AnimationName";
+
+		if (property in element.style) {
 		    animationSupport = true;
 		}
 	    }
+
 	    return animationSupport;
 	},
 	generate: function(frameData) {


### PR DESCRIPTION
This call:

``` javascript
var supported = $.keyframe.isSupported();
```

will now evaluate to **true** for Safari (Tested on Version 7.0.1 (9537.73.11)).

Please note, we have to "re-minify" to the .min.js file to reflect these changes.

Signed-off-by: Arné Schreuder arne@consulta.co.za
