### PR TITLE
initialize variable before use

### DIFF
--- a/jquery.keyframes.js
+++ b/jquery.keyframes.js
@@ -58,7 +58,7 @@
             return temp;
         },
         generate: function(frameData) {
-            var $elems, $frameStyle, css, frameName, property;
+            var $elems, $frameStyle, css, frameName, property, key;
             frameName = frameData.name || "";
             css = "@" + (this.getVendorPrefix()) + "keyframes " + frameName + " {";
 


### PR DESCRIPTION
initialize variable before use to not get an error when for instance minifying with "use strict"
